### PR TITLE
Disable RSpec/MultipleExpectations

### DIFF
--- a/config/rspec.yml
+++ b/config/rspec.yml
@@ -1,5 +1,8 @@
 RSpec/ExampleLength:
   Max: 10
+  
+RSpec/MultipleExpectations:
+  Enabled: false
 
 RSpec/MultipleMemoizedHelpers:
   Max: 10


### PR DESCRIPTION
Many specs are working with (1) http response, or (2) database record. Having to be forced into one expectation per test case and do the setup all over again in order to test one field is cumbersome and slow.