### PR TITLE
Rubocop updates

### DIFF
--- a/config/metrics.yml
+++ b/config/metrics.yml
@@ -2,7 +2,21 @@ Metrics/AbcSize:
   CountRepeatedAttributes: false
   Max: 25
   Exclude:
-    - 'db/migrate/**/*.rb'
+    - 'db/migrate/*.rb'
+    - 'db/data_migrate_after_db/*.rb'
+    - 'db/data_migrate_before_db/*.rb'
+
+Metrics/PerceivedComplexity:
+  Exclude:
+    - 'db/migrate/*.rb'
+    - 'db/data_migrate_after_db/*.rb'
+    - 'db/data_migrate_before_db/*.rb'
+
+Metrics/CyclomaticComplexity:
+  Exclude:
+    - 'db/migrate/*.rb'
+    - 'db/data_migrate_after_db/*.rb'
+    - 'db/data_migrate_before_db/*.rb'
 
 Metrics/MethodLength:
   Max: 40
@@ -15,3 +29,6 @@ Metrics/BlockLength:
     - 'Rakefile'
     - '**/*.rake'
     - 'spec/**/*.rb'
+    - 'config/**/**'
+  ExcludedMethods:
+    - included

--- a/config/rails.yml
+++ b/config/rails.yml
@@ -41,7 +41,7 @@ Rails/Pluck:
   Enabled: true
 
 Rails/PluckId:
-  Enabled: true
+  Enabled: false
 
 Rails/PluckInWhere:
   Enabled: true


### PR DESCRIPTION
- excluded db and data migrations from abcsize and complexities checks
- excluded config files from block length check
- excluded `included` blocks from block length check (this is used in concerns for example)
- disabled Rails/PluckId check - we have many instances of `array.pluck(:id)` which cant be replaced with `ids`