### PR TITLE
Change rubocop according to new convention

### DIFF
--- a/config/rspec.yml
+++ b/config/rspec.yml
@@ -9,3 +9,7 @@ RSpec/MultipleMemoizedHelpers:
 
 RSpec/NestedGroups:
   Max: 6
+  
+RSpec/FilePath:
+  Exclude:
+    - 'spec/requests/**/*.rb'


### PR DESCRIPTION
```
# config/routes.rb
namespace :api
  resources :items, only: %i[index create update]

# app/controllers/api/items_controller.rb
module Api
  class ItemsController
    def index
    def create
    def update

# spec/requests/api/items.rb
RSpec.describe Api::ItemsController
  describe 'GET /api/items'
  describe 'POST /api/items'
  describe 'PATCH /api/items/:id'
```