### PR TITLE
Exclude RSpec/ContextWording from shared contexts

### DIFF
--- a/config/rspec.yml
+++ b/config/rspec.yml
@@ -1,3 +1,7 @@
+RSpec/ContextWording:
+  Exclude:
+    - 'spec/support/shared/context/**/*.rb'
+
 RSpec/ExampleLength:
   Max: 30
 


### PR DESCRIPTION
For contexts like `android`, `frozen`, `sidekiq`, `account` or `user`.