### PR TITLE
allow let!

### DIFF
--- a/config/rspec.yml
+++ b/config/rspec.yml
@@ -13,6 +13,9 @@ RSpec/MultipleMemoizedHelpers:
 
 RSpec/NestedGroups:
   Max: 6
+
+RSpec/LetSetup:
+  Enabled: false
   
 RSpec/FilePath:
   Exclude:


### PR DESCRIPTION
Disable RSpec/LetSetup, so it will allow keep all variables in let blocks, like

```ruby
let(:menu_version) { create(:menu360_menu_version, menu: menu, account: store.account) }
# RSpec/LetSetup do not allow next line - I would like to allow it by this PR
let!(:menu_upload) { create(:menu360_menu_upload, api_user: store, menu_version: menu_version, status: 'running') }

it 'confirms upload' do
  expect do
    get(url, headers: headers)
    store.reload
  end.to change(store, :menu_sync_status).to(ApiUser::MENU_SYNC_SUCCESS)
end

```